### PR TITLE
update rust FFI bindings to use the correct parser symbol

### DIFF
--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -26,13 +26,13 @@
 use tree_sitter_language::LanguageFn;
 
 extern "C" {
-    fn tree_sitter_rust() -> *const ();
+    fn tree_sitter_verus() -> *const ();
 }
 
 /// The tree-sitter [`LanguageFn`][LanguageFn] for this grammar.
 ///
 /// [LanguageFn]: https://docs.rs/tree-sitter-language/*/tree_sitter_language/struct.LanguageFn.html
-pub const LANGUAGE: LanguageFn = unsafe { LanguageFn::from_raw(tree_sitter_rust) };
+pub const LANGUAGE: LanguageFn = unsafe { LanguageFn::from_raw(tree_sitter_verus) };
 
 /// The content of the [`node-types.json`][] file for this grammar.
 ///


### PR DESCRIPTION
The Rust bindings were still attempting to link against the old `tree_sitter_rust` symbol. This caused a linker error when attempting to use this crate as a dependency in other Rust projects.